### PR TITLE
Auto set VITE_SITE_URL for GitHub Pages in Vite actions

### DIFF
--- a/.github/workflows/test-vite-plus.yml
+++ b/.github/workflows/test-vite-plus.yml
@@ -30,3 +30,7 @@ jobs:
       - name: Verify Vite+ Outputs
         run: |
           if [ -z "${{ steps.vite_plus_action.outputs.node-version }}" ]; then exit 1; fi
+          if [ "$VITE_SITE_URL" != "https://${{ github.repository_owner }}.github.io" ]; then
+            echo "VITE_SITE_URL is not set correctly: $VITE_SITE_URL"
+            exit 1
+          fi

--- a/.github/workflows/test-vite.yml
+++ b/.github/workflows/test-vite.yml
@@ -17,7 +17,7 @@ jobs:
           rm -rf vite-project
           mkdir -p vite-project
           cd vite-project
-          echo '{"name": "vite-project", "scripts": {"build": "mkdir -p dist && touch dist/index.html"}}' > package.json
+          echo '{"name": "vite-project", "scripts": {"build": "mkdir -p dist && touch dist/index.html" }}' > package.json
           npm install --no-package-lock
 
       - name: Test Vite Action
@@ -30,3 +30,7 @@ jobs:
       - name: Verify Vite Outputs
         run: |
           if [ -z "${{ steps.vite_action.outputs.node-version }}" ]; then exit 1; fi
+          if [ "$VITE_SITE_URL" != "https://${{ github.repository_owner }}.github.io" ]; then
+            echo "VITE_SITE_URL is not set correctly: $VITE_SITE_URL"
+            exit 1
+          fi

--- a/vite-plus/action.yml
+++ b/vite-plus/action.yml
@@ -42,6 +42,7 @@ runs:
         REPO: ${{ github.event.repository.name }}
         OWNER: ${{ github.repository_owner }}
       run: |
+        echo "VITE_SITE_URL=https://${OWNER}.github.io" >> "$GITHUB_ENV"
         if [[ "$REPO" == "${OWNER}.github.io" ]]; then
           echo "BASE=/" >> "$GITHUB_ENV"
         else

--- a/vite/action.yml
+++ b/vite/action.yml
@@ -58,6 +58,7 @@ runs:
         REPO: ${{ github.event.repository.name }}
         OWNER: ${{ github.repository_owner }}
       run: |
+        echo "VITE_SITE_URL=https://${OWNER}.github.io" >> "$GITHUB_ENV"
         if [[ "$REPO" == "${OWNER}.github.io" ]]; then
           echo "BASE=/" >> "$GITHUB_ENV"
         else


### PR DESCRIPTION
This change ensures that `VITE_SITE_URL` is automatically available in the environment during Vite and Vite+ builds on GitHub Pages, defaulting to `https://${OWNER}.github.io`. This aligns with the behavior of the Astro action.

Updated actions:
- vite/action.yml
- vite-plus/action.yml

Updated test workflows:
- .github/workflows/test-vite.yml
- .github/workflows/test-vite-plus.yml

---
*PR created automatically by Jules for task [2655622909286689488](https://jules.google.com/task/2655622909286689488) started by @torn4dom4n*