### PR TITLE
Fix VITE_SITE_URL to include repository subpath for project sites

### DIFF
--- a/.github/workflows/test-vite-plus.yml
+++ b/.github/workflows/test-vite-plus.yml
@@ -28,9 +28,14 @@ jobs:
           build-command: "mkdir -p vp-project/dist && touch vp-project/dist/index.html"
 
       - name: Verify Vite+ Outputs
+        env:
+          REPO: ${{ github.event.repository.name }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          if [ -z "${{ steps.vite_plus_action.outputs.node-version }}" ]; then exit 1; fi
-          if [ "$VITE_SITE_URL" != "https://${{ github.repository_owner }}.github.io" ]; then
-            echo "VITE_SITE_URL is not set correctly: $VITE_SITE_URL"
-            exit 1
+          [[ -n "${{ steps.vite_plus_action.outputs.node-version }}" ]] || { echo "Node version output missing"; false; }
+          if [[ "$REPO" == "${OWNER}.github.io" ]]; then
+            EXPECTED_URL="https://${OWNER}.github.io"
+          else
+            EXPECTED_URL="https://${OWNER}.github.io/${REPO}"
           fi
+          [[ "$VITE_SITE_URL" == "$EXPECTED_URL" ]] || { echo "VITE_SITE_URL is not set correctly: $VITE_SITE_URL (expected $EXPECTED_URL)"; false; }

--- a/.github/workflows/test-vite.yml
+++ b/.github/workflows/test-vite.yml
@@ -28,9 +28,14 @@ jobs:
           build-command: "cd vite-project && npm run build"
 
       - name: Verify Vite Outputs
+        env:
+          REPO: ${{ github.event.repository.name }}
+          OWNER: ${{ github.repository_owner }}
         run: |
-          if [ -z "${{ steps.vite_action.outputs.node-version }}" ]; then exit 1; fi
-          if [ "$VITE_SITE_URL" != "https://${{ github.repository_owner }}.github.io" ]; then
-            echo "VITE_SITE_URL is not set correctly: $VITE_SITE_URL"
-            exit 1
+          [[ -n "${{ steps.vite_action.outputs.node-version }}" ]] || { echo "Node version output missing"; false; }
+          if [[ "$REPO" == "${OWNER}.github.io" ]]; then
+            EXPECTED_URL="https://${OWNER}.github.io"
+          else
+            EXPECTED_URL="https://${OWNER}.github.io/${REPO}"
           fi
+          [[ "$VITE_SITE_URL" == "$EXPECTED_URL" ]] || { echo "VITE_SITE_URL is not set correctly: $VITE_SITE_URL (expected $EXPECTED_URL)"; false; }

--- a/vite-plus/action.yml
+++ b/vite-plus/action.yml
@@ -48,10 +48,11 @@ runs:
         REPO: ${{ github.event.repository.name }}
         OWNER: ${{ github.repository_owner }}
       run: |
-        echo "VITE_SITE_URL=https://${OWNER}.github.io" >> "$GITHUB_ENV"
         if [[ "$REPO" == "${OWNER}.github.io" ]]; then
+          echo "VITE_SITE_URL=https://${OWNER}.github.io" >> "$GITHUB_ENV"
           echo "BASE=/" >> "$GITHUB_ENV"
         else
+          echo "VITE_SITE_URL=https://${OWNER}.github.io/${REPO}" >> "$GITHUB_ENV"
           echo "BASE=/${REPO}/" >> "$GITHUB_ENV"
         fi
 

--- a/vite/action.yml
+++ b/vite/action.yml
@@ -60,10 +60,11 @@ runs:
         REPO: ${{ github.event.repository.name }}
         OWNER: ${{ github.repository_owner }}
       run: |
-        echo "VITE_SITE_URL=https://${OWNER}.github.io" >> "$GITHUB_ENV"
         if [[ "$REPO" == "${OWNER}.github.io" ]]; then
+          echo "VITE_SITE_URL=https://${OWNER}.github.io" >> "$GITHUB_ENV"
           echo "BASE=/" >> "$GITHUB_ENV"
         else
+          echo "VITE_SITE_URL=https://${OWNER}.github.io/${REPO}" >> "$GITHUB_ENV"
           echo "BASE=/${REPO}/" >> "$GITHUB_ENV"
         fi
 


### PR DESCRIPTION
This PR updates the `VITE_SITE_URL` environment variable in the `vite` and `vite-plus` composite actions. Previously, it was hardcoded to `https://${OWNER}.github.io`, which is incorrect for project sites hosted at a subpath. The new logic conditionally appends the repository name to the URL, matching the existing `BASE` path logic. Test workflows have been updated to validate this behavior.

---
*PR created automatically by Jules for task [14457438412201517827](https://jules.google.com/task/14457438412201517827) started by @torn4dom4n*