### PR TITLE
Fix vite-plus action outputs

### DIFF
--- a/vite-plus/action.yml
+++ b/vite-plus/action.yml
@@ -15,7 +15,7 @@ inputs:
 outputs:
   node-version:
     description: "The Node.js version used"
-    value: ${{ steps.setup.outputs.node-version }}
+    value: ${{ steps.setup_vp.outputs.node-version }}
   package-manager:
     description: "The package manager used"
     value: ${{ steps.detect_env.outputs.package_manager }}
@@ -24,7 +24,7 @@ outputs:
     value: ${{ steps.detect_env.outputs.package_manager_version }}
   vp-version:
     description: "The version of Vite+ installed"
-    value: ${{ steps.setup.outputs.version }}
+    value: ${{ steps.setup_vp.outputs.version }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
Corrected the output mappings in the vite-plus composite action to ensure that node-version and vp-version are correctly populated from the setup_vp step.

---
*PR created automatically by Jules for task [14238434300230101063](https://jules.google.com/task/14238434300230101063) started by @torn4dom4n*