### PR TITLE
Fix Test Vite+ action fails

### DIFF
--- a/.github/workflows/test-vite-plus.yml
+++ b/.github/workflows/test-vite-plus.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/.github/workflows/test-vite-plus.yml
+++ b/.github/workflows/test-vite-plus.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/vite-plus/action.yml
+++ b/vite-plus/action.yml
@@ -15,7 +15,7 @@ inputs:
 outputs:
   node-version:
     description: "The Node.js version used"
-    value: ${{ steps.setup_vp.outputs.node-version }}
+    value: ${{ steps.detect_env.outputs.node_version }}
   package-manager:
     description: "The package manager used"
     value: ${{ steps.detect_env.outputs.package_manager }}
@@ -24,7 +24,7 @@ outputs:
     value: ${{ steps.detect_env.outputs.package_manager_version }}
   vp-version:
     description: "The version of Vite+ installed"
-    value: ${{ steps.setup_vp.outputs.version }}
+    value: ${{ steps.setup_vp.outputs.vp-version }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
Corrected output mappings in vite-plus/action.yml and added Node 24 enforcement in the test workflow to ensure consistency and reliability.

---
*PR created automatically by Jules for task [11098373822117936994](https://jules.google.com/task/11098373822117936994) started by @torn4dom4n*