### PR TITLE
feat(lint-format): use package manager to execute utility script

### DIFF
--- a/lint-format/action.yml
+++ b/lint-format/action.yml
@@ -28,7 +28,15 @@ runs:
 
     - name: Run lint/format scripts
       shell: bash
-      run: node "${{ github.action_path }}/../dist/run-scripts.js"
+      env:
+        PACKAGE_MANAGER: ${{ steps.setup.outputs.package-manager }}
+      run: |
+        case "$PACKAGE_MANAGER" in
+          bun) bun run "${{ github.action_path }}/../dist/run-scripts.js" ;;
+          pnpm) pnpm exec node "${{ github.action_path }}/../dist/run-scripts.js" ;;
+          yarn) yarn node "${{ github.action_path }}/../dist/run-scripts.js" ;;
+          *) npm exec -- node "${{ github.action_path }}/../dist/run-scripts.js" ;;
+        esac
 
     - name: Run autofix.ci
       uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1


### PR DESCRIPTION
Updated the 'lint-format' composite action to use the detected package manager to run the 'run-scripts.js' utility. This ensures that the appropriate runtime (like Bun) is used when available, and correctly passes the PACKAGE_MANAGER environment variable to the script.

Changes:
- Added a case statement in lint-format/action.yml to handle bun, pnpm, yarn, and npm.
- Passed PACKAGE_MANAGER environment variable to the execution step.
- Rebuilt dist/ assets to ensure they are up to date.

---
*PR created automatically by Jules for task [410574003616093204](https://jules.google.com/task/410574003616093204) started by @torn4dom4n*